### PR TITLE
Store BSNeuron constructor IDs

### DIFF
--- a/Source/Core/Simulator/BallAndStick/BSNeuron.cpp
+++ b/Source/Core/Simulator/BallAndStick/BSNeuron.cpp
@@ -13,7 +13,7 @@ namespace BallAndStick {
 
 //! Constructors
 BSNeuron::BSNeuron(int ID, Geometries::Geometry* soma, Geometries::Geometry* axon) {
-    ID = ID;
+    this->ID = ID;
     Class_ = CoreStructs::_BSNeuron;
     
     Morphology["soma"] = soma;

--- a/Source/Core/Simulator/BallAndStick/BSNeuron.test.cpp
+++ b/Source/Core/Simulator/BallAndStick/BSNeuron.test.cpp
@@ -61,6 +61,8 @@ struct BSNeuronTest : testing::Test {
 };
 
 TEST_F(BSNeuronTest, test_GetCellCenter_default) {
+    ASSERT_EQ(testBSNeuron->ID, 200);
+
     BG::NES::Simulator::Geometries::Vec3D cellCenter =
         testBSNeuron->GetCellCenter();
     BG::NES::Simulator::Geometries::Vec3D expectedCenter = testSoma->Center_um;


### PR DESCRIPTION
## Summary
- fix the public `BSNeuron` constructor so it stores the provided neuron ID on the inherited `Neuron::ID` field
- add a focused GTest assertion covering the constructor ID

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- `git diff --check`
- focused source probe confirming the self-assignment is gone and the constructor ID assertion is present
- clean patch apply to a temporary `origin/master` worktree

## Build note
- `cd Tools && bash Build.sh 6 Release` cannot configure in this checkout because `ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake` is missing and CMake cannot find a Unix Makefiles build program. The existing GTest target is also commented out in `Source/Core/CMakeLists.txt`, so `Tools/Test.sh` cannot run a generated test binary here.
