### PR TITLE
Use explicit NES RPC error status codes

### DIFF
--- a/Source/Core/RPC/RPCManager.cpp
+++ b/Source/Core/RPC/RPCManager.cpp
@@ -170,13 +170,13 @@ std::string RPCManager::NESRequest(std::string _JSONRequest, int _SimulationIDOv
         if (it == RequestHandlers_.end()) {
             Logger_->Log("Error, No Handler Exists For Call " + ReqFunc, 7);
             ReqResponseJSON["ReqID"] = ReqID;
-            ReqResponseJSON["StatusCode"] = 1; // unknown request *** TODO: use the right code
+            ReqResponseJSON["StatusCode"] = int(BGStatusCode::BGStatusInvalidParametersPassed);
             //Response = ReqResponseJSON.dump();
         } else {
             if (!it->second) {
                 ReqResponseJSON["ReqID"] = ReqID;
                 Logger_->Log("Error, Handler Is Null For Call " + ReqFunc + ", Continuing Anyway", 7);
-                // ReqResponseJSON["StatusCode"] = 1; // not a valid NES request *** TODO: use the right code
+                ReqResponseJSON["StatusCode"] = int(BGStatusCode::BGStatusGeneralFailure);
             } else {
                 // Logger_->Log("DEBUG -> Got Request For '" + ReqFunc + "'", 0);
                 if (_SimulationIDOverride != -1) {


### PR DESCRIPTION
## Summary
- return `BGStatusInvalidParametersPassed` for unknown NES batched RPC request names
- return `BGStatusGeneralFailure` when a registered request handler is unexpectedly null
- remove the stale TODOs around placeholder status-code handling

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- `git diff --check`
- focused source probe confirming explicit enum-backed status codes and removed status-code TODOs
- clean patch apply to a temporary `origin/master` worktree

## Build note
- `cd Tools && bash Build.sh 6 Release` reports configure/build errors in this checkout because `ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake` is missing and CMake cannot find a Unix Makefiles build program / `CMAKE_MAKE_PROGRAM`.
