### PR TITLE
Honor Vec3D string precision

### DIFF
--- a/Source/Core/Simulator/Geometries/VecTools.cpp
+++ b/Source/Core/Simulator/Geometries/VecTools.cpp
@@ -1,4 +1,3 @@
-#include <iomanip>
 #include <sstream>
 
 #include <Simulator/Geometries/VecTools.h>
@@ -123,7 +122,8 @@ std::vector<float> Vec3D::AsFloatVector() const {
 //! Return string representation of vector.
 std::string Vec3D::str(int precision) const {
     std::stringstream s;
-    s << std::setprecision(precision) << this->x << ',' << this->y << ',' << this->z;
+    s.precision(precision);
+    s << this->x << ',' << this->y << ',' << this->z;
     return s.str();
 }
 

--- a/Source/Core/Simulator/Geometries/VecTools.cpp
+++ b/Source/Core/Simulator/Geometries/VecTools.cpp
@@ -1,3 +1,4 @@
+#include <iomanip>
 #include <sstream>
 
 #include <Simulator/Geometries/VecTools.h>
@@ -120,10 +121,9 @@ std::vector<float> Vec3D::AsFloatVector() const {
 }
 
 //! Return string representation of vector.
-//! TODO: Add in the precision code.
 std::string Vec3D::str(int precision) const {
     std::stringstream s;
-    s << this->x << ',' << this->y << ',' << this->z;
+    s << std::setprecision(precision) << this->x << ',' << this->y << ',' << this->z;
     return s.str();
 }
 

--- a/Source/Core/Simulator/Geometries/VecTools.test.cpp
+++ b/Source/Core/Simulator/Geometries/VecTools.test.cpp
@@ -140,3 +140,11 @@ TEST_F(Vec3DTest, test_Maximum_default) {
     float max = testVec3D_2->Max();
     ASSERT_EQ(max, 5.6f);
 }
+
+TEST_F(Vec3DTest, test_StringPrecision_default) {
+
+    BG::NES::Simulator::Geometries::Vec3D vec{
+        1.23456f, 7.89123f, 0.000123456f};
+
+    ASSERT_EQ(vec.str(3), "1.23,7.89,0.000123");
+}


### PR DESCRIPTION
## Summary
- make `Vec3D::str(int precision)` apply the requested stream precision
- remove the completed precision TODO
- add a focused GTest assertion for `str(3)` output

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- `git diff --check`
- focused C++17 probe for `Vec3D::str(3)` and `Vec3D::str(6)` output
- clean patch apply to a temporary `origin/master` worktree

## Build note
- `cd Tools && bash Build.sh 6 Release` reports configure/build errors in this checkout because `ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake` is missing and CMake cannot find a Unix Makefiles build program / `CMAKE_MAKE_PROGRAM`. The existing GTest target is commented out in `Source/Core/CMakeLists.txt`, so the added assertion is not runnable through the repo test target here.
