### PR TITLE
Remove manual config parser destructor

### DIFF
--- a/Source/Core/Config/ConfigurationManager.cpp
+++ b/Source/Core/Config/ConfigurationManager.cpp
@@ -14,8 +14,9 @@ Manager::Manager(int _NumArgs, char** _Args) {
     // ArgParser.~ArgumentParser();
 
     // Now Load Configuration File
-    ConfigFileParser ConfigParser(Config_);
-    ConfigParser.~ConfigFileParser();
+    {
+        ConfigFileParser ConfigParser(Config_);
+    }
 
     if (_NumArgs > 1) {
         std::cout<<"Detected that you're specifying a profiling argument, NES isn't intended to take arguments normally, so if you didn't expect this, use the config file instead!\n";


### PR DESCRIPTION
Summary:
- remove the explicit destructor call on the stack-local ConfigFileParser
- keep the parser sequencing through normal block scope lifetime

Verification:
- git diff --check
- grep check confirming no live manual destructor call remains in ConfigurationManager.cpp
- clean patch apply against origin/master
- cd Tools && bash Build.sh 6 Release (local configure/build still reports the missing vcpkg toolchain file, missing CMAKE_MAKE_PROGRAM, and unset compiler/build tool state before compilation)

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.