### PR TITLE
Return electrode attachment validation errors

### DIFF
--- a/Source/Core/Simulator/RPC/SimulationRPCInterface.cpp
+++ b/Source/Core/Simulator/RPC/SimulationRPCInterface.cpp
@@ -1069,49 +1069,49 @@ std::string SimulationRPCInterface::AttachRecordingElectrodes(std::string _JSONR
 
     nlohmann::json::iterator ElectrodeSpecsIterator;
     if (!Handle.FindPar("ElectrodeSpecs", ElectrodeSpecsIterator, const_cast<nlohmann::json&>(Handle.ReqJSON()))) {
-        Handle.ErrResponse();
+        return Handle.ErrResponse();
     }
     auto ElectrodeList = ElectrodeSpecsIterator.value();
     if (!ElectrodeList.is_array()) {
-        Handle.ErrResponse(API::BGStatusCode::BGStatusInvalidParametersPassed);
+        return Handle.ErrResponse(API::BGStatusCode::BGStatusInvalidParametersPassed);
     }
     for (auto& ElectodeData : ElectrodeList) {
 
         // Collect electrode parameters and make electrode
         Tools::RecordingElectrode E(Handle.Sim());
         if (!Handle.GetParString("name", E.Name, ElectodeData)) {
-            Handle.ErrResponse();
+            return Handle.ErrResponse();
         }
         std::vector<float> TipPosition;
         if (!Handle.GetParVecFloat("tip_position", TipPosition, ElectodeData)) {
-            Handle.ErrResponse();
+            return Handle.ErrResponse();
         }
         std::vector<float> EndPosition;
         if (!Handle.GetParVecFloat("end_position", EndPosition, ElectodeData)) {
-            Handle.ErrResponse();
+            return Handle.ErrResponse();
         }
         if ((TipPosition.size()<3) || (EndPosition.size()<3)) {
-            Handle.ErrResponse(API::BGStatusCode::BGStatusInvalidParametersPassed);
+            return Handle.ErrResponse(API::BGStatusCode::BGStatusInvalidParametersPassed);
         }
         E.TipPosition_um = TipPosition;
         E.EndPosition_um = EndPosition;
         if (!Handle.GetParFloat("noise_level", E.NoiseLevel, ElectodeData)) {
-            Handle.ErrResponse();
+            return Handle.ErrResponse();
         }
         nlohmann::json::iterator SitesIterator;
         if (!Handle.FindPar("sites", SitesIterator, ElectodeData)) {
-            Handle.ErrResponse();
+            return Handle.ErrResponse();
         }
         if (!SitesIterator.value().is_array()) {
-            Handle.ErrResponse(API::BGStatusCode::BGStatusInvalidParametersPassed);
+            return Handle.ErrResponse(API::BGStatusCode::BGStatusInvalidParametersPassed);
         }
         for (auto& SiteData : SitesIterator.value()) {
             std::vector<float> SitePosition;
             if (!Handle.GetParVecFloat("", SitePosition, SiteData)) {
-                Handle.ErrResponse();
+                return Handle.ErrResponse();
             }
             if (SitePosition.size()<3) {
-                Handle.ErrResponse(API::BGStatusCode::BGStatusInvalidParametersPassed);
+                return Handle.ErrResponse(API::BGStatusCode::BGStatusInvalidParametersPassed);
             }
             E.Sites.emplace_back(SitePosition);
         }


### PR DESCRIPTION
Summary
- Return existing RPC error responses immediately from `Simulation/AttachRecordingElectrodes` validation failures.
- Prevent invalid electrode specs from falling through into iterator access or electrode creation after an error response is prepared.

Verification
- Source probe confirming `AttachRecordingElectrodes` has no bare `Handle.ErrResponse(...)` validation calls and returns 12 error responses including the existing initial handler error path.
- git diff --check
- Clean patch apply against origin/master
- `cmake -S . -B /tmp/nes-return-electrode-errors-cmake` was attempted but local configure is blocked by the known missing `ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake` toolchain file and unset `CMAKE_MAKE_PROGRAM` for Unix Makefiles.

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.
