### PR TITLE
Fix recording electrode site direction

### DIFF
--- a/Source/Core/Simulator/Structs/RecordingElectrode.cpp
+++ b/Source/Core/Simulator/Structs/RecordingElectrode.cpp
@@ -50,7 +50,7 @@ RecordingElectrode::RecordingElectrode(
 //       At present, this is using only the z-coord of eloc_ratio as
 //       a position along the center line of the vector between tip and end.
 Geometries::Vec3D RecordingElectrode::CoordsElectrodeToSystem(Geometries::Vec3D eLocRatio) {
-    auto toAdd = (this->TipPosition_um - this->EndPosition_um) * eLocRatio.z;
+    auto toAdd = (this->EndPosition_um - this->TipPosition_um) * eLocRatio.z;
     return this->TipPosition_um + toAdd;
 };
 

--- a/Source/Core/Simulator/Structs/RecordingElectrode.test.cpp
+++ b/Source/Core/Simulator/Structs/RecordingElectrode.test.cpp
@@ -55,10 +55,11 @@ struct RecordingElectrodeTest : testing::Test {
 
 TEST_F(RecordingElectrodeTest, test_CoordsElectrodeToSystem_default) {
     BG::NES::Simulator::Geometries::Vec3D eLocRatio(0.0, 0.5, 0.2);
-    auto toAdd = (testElectrode->TipPosition_um - testElectrode->EndPosition_um) * eLocRatio.z;
+    auto toAdd = (testElectrode->EndPosition_um - testElectrode->TipPosition_um) * eLocRatio.z;
     auto expectedSysLoc_um = testElectrode->TipPosition_um + toAdd;
 
     ASSERT_TRUE(testElectrode->CoordsElectrodeToSystem(eLocRatio) == expectedSysLoc_um);
+    ASSERT_TRUE(testElectrode->CoordsElectrodeToSystem(BG::NES::Simulator::Geometries::Vec3D(0.0, 0.0, 1.0)) == testElectrode->EndPosition_um);
 }
 
 TEST_F(RecordingElectrodeTest, test_InitSystemCoordSiteLocations_default) {


### PR DESCRIPTION
Summary
- Correct recording-electrode site placement so the centerline vector points from tip to end.
- Update the existing unit test and add an explicit ratio-1.0 assertion against `EndPosition_um`.

Verification
- Source probe confirming `CoordsElectrodeToSystem()` uses `EndPosition_um - TipPosition_um` and the test asserts ratio `1.0` maps to `EndPosition_um`.
- git diff --check
- Clean patch apply against origin/master
- `clang++ -std=c++17 -I Source/Core -I ThirdParty/json/single_include -fsyntax-only Source/Core/Simulator/Structs/RecordingElectrode.cpp` was attempted but this checkout has no vendored `nlohmann/json.hpp` include path available.
- `cmake -S . -B /tmp/nes-electrode-site-direction-cmake` was attempted but local configure is blocked by the known missing `ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake` toolchain file and unset `CMAKE_MAKE_PROGRAM` for Unix Makefiles.

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.
