### PR TITLE
Fix calcium voxel threaded clear

### DIFF
--- a/Source/Core/VSDA/Ca/VoxelSubsystem/Structs/CaVoxelArray.cpp
+++ b/Source/Core/VSDA/Ca/VoxelSubsystem/Structs/CaVoxelArray.cpp
@@ -93,16 +93,29 @@ void VoxelArray::ClearArray() {
 void VoxelArray::ClearArrayThreaded(int _NumThreads) {
 
     // Calculate Start Ptr, StepSize
-    uint64_t StepSize = DataMaxLength_ / _NumThreads;
+    if (DataMaxLength_ == 0) {
+        return;
+    }
+    if (_NumThreads <= 0) {
+        _NumThreads = 1;
+    }
+    uint64_t ThreadCount = static_cast<uint64_t>(_NumThreads);
+    if (ThreadCount > DataMaxLength_) {
+        ThreadCount = DataMaxLength_;
+    }
+    uint64_t StepSize = DataMaxLength_ / ThreadCount;
     VoxelType* StartAddress = Data_.get();
 
     // Create a bunch of memset tasks
     std::vector<std::future<int>> AsyncTasks;
-    for (size_t i = 0; i < _NumThreads; i++) {
-        VoxelType* ThreadStartAddress = StartAddress + (StepSize * i);
-        assert(ThreadStartAddress + StepSize <= StartAddress + DataMaxLength_);
-        AsyncTasks.push_back(std::async(std::launch::async, [ThreadStartAddress, StepSize]{
-            std::memset(ThreadStartAddress, 0, StepSize);
+    for (uint64_t i = 0; i < ThreadCount; i++) {
+        uint64_t StartIndex = StepSize * i;
+        uint64_t EndIndex = (i == ThreadCount - 1) ? DataMaxLength_ : StartIndex + StepSize;
+        VoxelType* ThreadStartAddress = StartAddress + StartIndex;
+        uint64_t ThreadLength = EndIndex - StartIndex;
+        assert(ThreadStartAddress + ThreadLength <= StartAddress + DataMaxLength_);
+        AsyncTasks.push_back(std::async(std::launch::async, [ThreadStartAddress, ThreadLength]{
+            std::memset(ThreadStartAddress, 0, ThreadLength * sizeof(VoxelType));
             return 0;
         }));
     }


### PR DESCRIPTION
Summary
- Clear calcium voxel threaded ranges using element counts converted to byte counts.
- Clamp nonpositive thread counts to one, cap worker ranges at the voxel count, and include the final remainder range.
- Return early for empty voxel arrays.

Verification
- Source probe confirming the threaded clear no longer passes element counts directly to `memset`.
- Standalone C++17 probe covering empty arrays and thread counts `0`, `1`, `3`, and `64`, verifying every `VoxelType` field is cleared.
- git diff --check
- Clean patch apply against origin/master
- `cmake -S . -B /tmp/nes-ca-voxel-threaded-clear-cmake` was attempted but local configure is blocked by the known missing `ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake` toolchain file and unset `CMAKE_MAKE_PROGRAM` for Unix Makefiles.

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.
