### PR TITLE
Clamp RPC worker count

### DIFF
--- a/Source/Core/RPC/RPCManager.cpp
+++ b/Source/Core/RPC/RPCManager.cpp
@@ -42,7 +42,10 @@ RPCManager::RPCManager(Config::Config* _Config, BG::Common::Logger::LoggingSyste
     AddRoute("SetCallback", Logger_, [this](std::string RequestJSON){ return SetupCallback(RequestJSON);});
     
 
-    int ThreadCount = std::thread::hardware_concurrency();
+    unsigned int ThreadCount = std::thread::hardware_concurrency();
+    if (ThreadCount == 0) {
+        ThreadCount = 1;
+    }
 
     // Reduced threaidng mode for debugging
     #ifdef REDUCED_THREADING_DEBUG


### PR DESCRIPTION
Summary
- Clamp the NES RPC server worker count to at least one when `std::thread::hardware_concurrency()` returns zero.
- Keep `REDUCED_THREADING_DEBUG` behavior intact after the fallback.

Verification
- Source probe confirming the raw hardware-concurrency value is clamped before `async_run()`.
- Standalone C++17 worker-count probe for detected counts `0`, `1`, and `8`.
- git diff --check
- Clean patch apply against origin/master
- Clean patch apply against NES PR #95 head
- `cmake -S . -B /tmp/nes-rpc-worker-count-fallback-cmake` was attempted but local configure is blocked by the known missing `ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake` toolchain file and unset `CMAKE_MAKE_PROGRAM` for Unix Makefiles.

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.
