### PR TITLE
Fix EM voxel threaded clear ranges

### DIFF
--- a/Source/Core/VSDA/EM/VoxelSubsystem/Structs/VoxelArray.cpp
+++ b/Source/Core/VSDA/EM/VoxelSubsystem/Structs/VoxelArray.cpp
@@ -101,7 +101,17 @@ void VoxelArray::ClearArray() {
 
 void VoxelArray::ClearArrayThreaded(int _NumThreads) {
 
-    uint64_t ElementStepSize = DataMaxLength_ / _NumThreads;
+    if (DataMaxLength_ == 0) {
+        return;
+    }
+    if (_NumThreads <= 0) {
+        _NumThreads = 1;
+    }
+    uint64_t ThreadCount = static_cast<uint64_t>(_NumThreads);
+    if (ThreadCount > DataMaxLength_) {
+        ThreadCount = DataMaxLength_;
+    }
+    uint64_t ElementStepSize = DataMaxLength_ / ThreadCount;
     // VoxelType* StartAddress = Data_.get();
 
     // Initializer
@@ -110,10 +120,10 @@ void VoxelArray::ClearArrayThreaded(int _NumThreads) {
 
     // Create a bunch of memset tasks
     std::vector<std::future<int>> AsyncTasks;
-    for (size_t i = 0; i < _NumThreads; i++) {
+    for (uint64_t i = 0; i < ThreadCount; i++) {
         // VoxelType* ThreadStartAddress = StartAddress + (ElementStepSize * i);
         uint64_t ThreadStartIndex = (ElementStepSize * i);
-        uint64_t ThreadEndIndex = (ElementStepSize * i) + ElementStepSize;
+        uint64_t ThreadEndIndex = (i == ThreadCount - 1) ? DataMaxLength_ : ThreadStartIndex + ElementStepSize;
         VoxelType* Array = Data_.get();
 
         AsyncTasks.push_back(std::async(std::launch::async, [Array, ThreadStartIndex, ThreadEndIndex, Empty]{


### PR DESCRIPTION
Summary
- Clamp EM voxel threaded clear thread counts to avoid divide-by-zero when hardware concurrency is zero.
- Cap worker ranges at the voxel count and make the final range clear through `DataMaxLength_` so remainders are cleared.

Verification
- Source probe confirming `ClearArrayThreaded()` no longer divides by `_NumThreads` directly and assigns the final range through `DataMaxLength_`.
- Standalone C++17 clear probe covering empty arrays and thread counts `0`, `1`, `3`, and `64`, verifying every `VoxelType` field is reset.
- git diff --check
- Clean patch apply against origin/master
- `cmake -S . -B /tmp/nes-em-voxel-threaded-clear-cmake` was attempted but local configure is blocked by the known missing `ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake` toolchain file and unset `CMAKE_MAKE_PROGRAM` for Unix Makefiles.

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.
