### PR TITLE
Use recorded calcium sample times for renders

### DIFF
--- a/Source/Core/VSDA/Ca/VoxelSubsystem/CaSubRegionRenderer.cpp
+++ b/Source/Core/VSDA/Ca/VoxelSubsystem/CaSubRegionRenderer.cpp
@@ -46,13 +46,15 @@ bool CaRenderSubRegion(BG::Common::Logger::LoggingSystem* _Logger, SubRegion* _S
 
 
     std::vector<std::vector<float>> CalciumIndexes;
-    float CalciumTimestep = 50.; // Randal - this is done since we want to know how much time passes between each step
-    // That's why I had the GetCalciumConcentrationTimestep
+    float CalciumTimestep = 0.0f;
     bool Status = VoxelArrayGenerator::CalculateCalciumConcentrations(_Logger, Sim, &CalciumIndexes);
     if (!Status) {
         return false;
     }
-    // get timestep here!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    Status = VoxelArrayGenerator::GetCalciumConcentrationTimestep(_Logger, Sim, &CalciumTimestep);
+    if (!Status) {
+        return false;
+    }
 
 
     CaData_->CalciumConcentrationByIndex_ = &CalciumIndexes;

--- a/Source/Core/VSDA/Ca/VoxelSubsystem/CaVoxelArrayRenderer.cpp
+++ b/Source/Core/VSDA/Ca/VoxelSubsystem/CaVoxelArrayRenderer.cpp
@@ -82,7 +82,11 @@ std::vector<std::string> CaRenderSliceFromArray(BG::Common::Logger::LoggingSyste
 
                 // Calculate the filename of the image to be generated, add to list of generated images
                 std::string DirectoryPath = "Renders/" + _FilePrefix + "/Slice" + std::to_string(SliceNumber + _SliceOffset) + "/";
-                DirectoryPath += "Timestep" + std::to_string(_CaData->CalciumConcentrationTimestep_ms * CalciumConcentrationIndex) + "/"; // fixme - make this done by a list of timesteps instead of a hard-coded single timestep
+                float CalciumSampleTime_ms = _CaData->CalciumConcentrationTimestep_ms * CalciumConcentrationIndex;
+                if (_CaData->CaImaging.TRecorded_ms.size() > static_cast<size_t>(CalciumConcentrationIndex)) {
+                    CalciumSampleTime_ms = _CaData->CaImaging.TRecorded_ms[CalciumConcentrationIndex];
+                }
+                DirectoryPath += "Timestep" + std::to_string(CalciumSampleTime_ms) + "/";
                 double RoundedXCoord = std::ceil(((CameraStepSizeX_um * XStep) + _OffsetX) * 100.0) / 100.0;
                 double RoundedYCoord = std::ceil(((CameraStepSizeY_um * YStep) + _OffsetY) * 100.0) / 100.0;
                 std::string FilePath = "X" + std::to_string(RoundedXCoord) + "_Y" + std::to_string(RoundedYCoord) + ".png";

--- a/Source/Core/VSDA/Ca/VoxelSubsystem/ShapeToVoxel/CalciumConcentration.cpp
+++ b/Source/Core/VSDA/Ca/VoxelSubsystem/ShapeToVoxel/CalciumConcentration.cpp
@@ -76,7 +76,27 @@ float ComponentSampledCalciumConcentration(Simulator::Simulation* _Simulation, i
  *   meant was that you wanted to know the simulation time-point of a specific Ca sample by its _SampleIdx.
  */
 bool GetCalciumConcentrationTimestep(BG::Common::Logger::LoggingSystem *_Logger, Simulator::Simulation* _Simulation, float* _Timestep){
-	// *** Don't know how to make this, please see alternative function below where I make some assumptions about what was intended!
+	if (_Simulation == nullptr || _Simulation->CaData_ == nullptr || _Timestep == nullptr) {
+		if (_Logger != nullptr) {
+			_Logger->Log("Failed To Get Calcium Concentration Timestep, Invalid Input", 7);
+		}
+		return false;
+	}
+
+	const std::vector<float>& RecordedTimes = _Simulation->CaData_->CaImaging.TRecorded_ms;
+	if (RecordedTimes.empty()) {
+		if (_Logger != nullptr) {
+			_Logger->Log("Failed To Get Calcium Concentration Timestep, No Calcium Timesteps Recorded", 7);
+		}
+		return false;
+	}
+
+	if (RecordedTimes.size() == 1) {
+		*_Timestep = 0.0f;
+		return true;
+	}
+
+	*_Timestep = RecordedTimes[1] - RecordedTimes[0];
 	return true;
 }
 


### PR DESCRIPTION
## Summary
- derive the calcium concentration timestep from recorded calcium imaging sample times instead of using a hard-coded `50` ms value
- name calcium render timestep directories from `CaImaging.TRecorded_ms` when available, with the existing interval multiplication as a fallback
- keep render task indexing unchanged

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- `rg -n "CalciumTimestep = 50|get timestep here|hard-coded single timestep|GetCalciumConcentrationTimestep|CalciumSampleTime_ms|TRecorded_ms" Source/Core/VSDA/Ca/VoxelSubsystem/CaSubRegionRenderer.cpp Source/Core/VSDA/Ca/VoxelSubsystem/CaVoxelArrayRenderer.cpp Source/Core/VSDA/Ca/VoxelSubsystem/ShapeToVoxel/CalciumConcentration.cpp`
- standalone C++17 probe for timestep extraction and render sample-time fallback
- `git diff --check`
- clean patch apply against a fresh `origin/master` checkout with `git apply --check --whitespace=error-all`

Local CMake configure remains blocked by missing `ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake` and unset Unix Makefiles build tooling (`CMAKE_MAKE_PROGRAM`).
