### PR TITLE
Remove dead EM voxel array allocation

### DIFF
--- a/Source/Core/VSDA/EM/VoxelSubsystem/EMSubRegion.cpp
+++ b/Source/Core/VSDA/EM/VoxelSubsystem/EMSubRegion.cpp
@@ -205,7 +205,6 @@ bool EMRenderSubRegion(BG::Common::Logger::LoggingSystem* _Logger, SubRegion* _S
     uint64_t TargetArraySize = RequestedRegion.GetVoxelSize(VSDAData_->Params_.VoxelResolution_um);
     if (VSDAData_->Array_.get() == nullptr || VSDAData_->Array_->GetSize() <= TargetArraySize) {
         _Logger->Log("Voxel Array Does Not Exist Yet Or Is Wrong Size, (Re)Creating Now", 2);
-        VSDAData_->Array_ = std::make_unique<VoxelArray>(_Logger, ScanRegion(), 99.);
         VSDAData_->Array_ = std::make_unique<VoxelArray>(_Logger, RequestedRegion, VSDAData_->Params_.VoxelResolution_um);
     } else {
         _Logger->Log("Reusing Existing Voxel Array, Clearing Data", 2);


### PR DESCRIPTION
## Summary
- remove an immediately overwritten placeholder `VoxelArray` allocation in the EM subregion render path
- keep the real requested-region allocation unchanged

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- `rg -n "make_unique<VoxelArray>\\(_Logger|Voxel Array Does Not Exist" Source/Core/VSDA/EM/VoxelSubsystem/EMSubRegion.cpp`
- source probe confirming the placeholder `ScanRegion(), 99.` allocation is gone and the requested-region allocation remains once
- `git diff --check`
- clean patch apply against a fresh `origin/master` checkout with `git apply --check --whitespace=error-all`

Local CMake configure remains blocked by missing `ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake` and unset Unix Makefiles build tooling (`CMAKE_MAKE_PROGRAM`).
