### PR TITLE
Use created simulation in profiling setup

### DIFF
--- a/Source/Core/Profiling/ProfilingManager.cpp
+++ b/Source/Core/Profiling/ProfilingManager.cpp
@@ -72,7 +72,7 @@ int Manager(BG::Common::Logger::LoggingSystem* _Logger, Config::Config* _Config,
             S.Center_um.x = CenterPosX;
             S.Center_um.y = CenterPosY;
             S.Center_um.z = CenterPosZ;
-            Simulator::Simulation* ThisSimulation = (*Simulations)[0].get();
+            Simulator::Simulation* ThisSimulation = Sim;
             S.ID = ThisSimulation->Collection.Geometries.size();
             ThisSimulation->Collection.Geometries.push_back(S);
 
@@ -201,7 +201,7 @@ int Manager(BG::Common::Logger::LoggingSystem* _Logger, Config::Config* _Config,
             S.Center_um.x = CenterPosX;
             S.Center_um.y = CenterPosY;
             S.Center_um.z = CenterPosZ;
-            Simulator::Simulation* ThisSimulation = (*Simulations)[0].get();
+            Simulator::Simulation* ThisSimulation = Sim;
             S.ID = ThisSimulation->Collection.Geometries.size();
             ThisSimulation->Collection.Geometries.push_back(S);
 
@@ -289,7 +289,7 @@ int Manager(BG::Common::Logger::LoggingSystem* _Logger, Config::Config* _Config,
             S.End1Radius_um = Radius_um;
             S.End0Pos_um = Simulator::Geometries::Vec3D(CenterPosX, CenterPosY, CenterPosZ);
             S.End1Pos_um = Simulator::Geometries::Vec3D(CenterPos2X, CenterPos2Y, CenterPos2Z);
-            Simulator::Simulation* ThisSimulation = (*Simulations)[0].get();
+            Simulator::Simulation* ThisSimulation = Sim;
             S.ID = ThisSimulation->Collection.Geometries.size();
             ThisSimulation->Collection.Geometries.push_back(S);
 
@@ -374,7 +374,7 @@ int Manager(BG::Common::Logger::LoggingSystem* _Logger, Config::Config* _Config,
             S.Name = Name;
             S.Center_um = Simulator::Geometries::Vec3D(CenterPosX, CenterPosY, CenterPosZ);
             S.Dims_um = Simulator::Geometries::Vec3D(SizeX, SizeY, SizeZ);
-            Simulator::Simulation* ThisSimulation = (*Simulations)[0].get();
+            Simulator::Simulation* ThisSimulation = Sim;
             S.ID = ThisSimulation->Collection.Geometries.size();
             ThisSimulation->Collection.Geometries.push_back(S);
 
@@ -460,7 +460,7 @@ int Manager(BG::Common::Logger::LoggingSystem* _Logger, Config::Config* _Config,
             S.Center_um.x = CenterPosX;
             S.Center_um.y = CenterPosY;
             S.Center_um.z = CenterPosZ;
-            Simulator::Simulation* ThisSimulation = (*Simulations)[0].get();
+            Simulator::Simulation* ThisSimulation = Sim;
             S.ID = ThisSimulation->Collection.Geometries.size();
             ThisSimulation->Collection.Geometries.push_back(S);
 
@@ -530,7 +530,7 @@ int Manager(BG::Common::Logger::LoggingSystem* _Logger, Config::Config* _Config,
             S.Name = Name;
             S.Center_um = Simulator::Geometries::Vec3D(CenterPosX, CenterPosY, CenterPosZ);
             S.Dims_um = Simulator::Geometries::Vec3D(SizeX, SizeY, SizeZ);
-            Simulator::Simulation* ThisSimulation = (*Simulations)[0].get();
+            Simulator::Simulation* ThisSimulation = Sim;
             S.ID = ThisSimulation->Collection.Geometries.size();
             ThisSimulation->Collection.Geometries.push_back(S);
 
@@ -612,7 +612,7 @@ int Manager(BG::Common::Logger::LoggingSystem* _Logger, Config::Config* _Config,
             S.Name = Name;
             S.Center_um = Simulator::Geometries::Vec3D(CenterPosX, CenterPosY, CenterPosZ);
             S.Dims_um = Simulator::Geometries::Vec3D(SizeX, SizeY, SizeZ);
-            Simulator::Simulation* ThisSimulation = (*Simulations)[0].get();
+            Simulator::Simulation* ThisSimulation = Sim;
             S.ID = ThisSimulation->Collection.Geometries.size();
             ThisSimulation->Collection.Geometries.push_back(S);
 
@@ -645,7 +645,7 @@ int Manager(BG::Common::Logger::LoggingSystem* _Logger, Config::Config* _Config,
             S.Center_um.x = CenterPosX;
             S.Center_um.y = CenterPosY;
             S.Center_um.z = CenterPosZ;
-            Simulator::Simulation* ThisSimulation = (*Simulations)[0].get();
+            Simulator::Simulation* ThisSimulation = Sim;
             S.ID = ThisSimulation->Collection.Geometries.size();
             ThisSimulation->Collection.Geometries.push_back(S);
 


### PR DESCRIPTION
## Summary
- make profiling geometry/compartment generation write to the simulation each profiling mode just created
- avoid writing generated profiling shapes into `Simulations[0]` when another simulation already exists

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- `rg -n "ThisSimulation = \\(\\*Simulations\\)\\[0\\]\\.get\\(\\)|ThisSimulation = Sim|SimID|push_back\\(std::make_unique<Simulator::Simulation" Source/Core/Profiling/ProfilingManager.cpp`
- source probe confirming no live `(*Simulations)[0]` profiling target remains and eight live assignments use `Sim`
- standalone C++17 probe showing the old target writes to the first simulation while the new target writes to the created simulation
- `git diff --check`
- clean patch apply against a fresh `origin/master` checkout with `git apply --check --whitespace=error-all`

Local CMake configure remains blocked by missing `ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake` and unset Unix Makefiles build tooling (`CMAKE_MAKE_PROGRAM`).
