### PR TITLE
Fix EM render Y image count

### DIFF
--- a/Source/Core/VSDA/EM/EMRenderer.cpp
+++ b/Source/Core/VSDA/EM/EMRenderer.cpp
@@ -93,9 +93,9 @@ bool ExecuteSubRenderOperations(Config::Config* _Config, BG::Common::Logger::Log
     double ImageStepSizeX_um = (Params->ImageWidth_px / Params->NumPixelsPerVoxel_px) * Params->VoxelResolution_um * (1 - (double(Params->ScanRegionOverlap_percent) / 100.));
     double ImageStepSizeY_um = (Params->ImageHeight_px / Params->NumPixelsPerVoxel_px) * Params->VoxelResolution_um * (1 - (double(Params->ScanRegionOverlap_percent) / 100.));
     int NumImagesInXDimension_img = ceil(BaseRegion->SizeX() / ImageStepSizeX_um);
-    int NumImagesInYDimension_img = ceil(BaseRegion->SizeX() / ImageStepSizeY_um);
+    int NumImagesInYDimension_img = ceil(BaseRegion->SizeY() / ImageStepSizeY_um);
     _Simulation->VSDAData_->TotalImagesX_ = NumImagesInXDimension_img;
-    _Simulation->VSDAData_->TotalImagesY_ = NumImagesInXDimension_img;
+    _Simulation->VSDAData_->TotalImagesY_ = NumImagesInYDimension_img;
     _Logger->Log("Identified The Total Number Of Images To Be '" + std::to_string(NumImagesInXDimension_img) + "'X, '" + std::to_string(NumImagesInYDimension_img) + "'Y", 4);
 
     // Nextly, we're going to figure out the step size information for the subregions.


### PR DESCRIPTION
Summary:
- compute EM render Y image count from BaseRegion->SizeY()
- store the Y image count in VSDAData_->TotalImagesY_ instead of reusing the X count

Verification:
- git diff --check
- source probe for old/new EMRenderer count expressions
- standalone C++ non-square region arithmetic probe: 12x9
- clean patch apply against origin/master
- cmake -S . -B /tmp/nes-em-render-y-count-cmake (blocked: missing ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake and Unix Makefiles build program / CMAKE_MAKE_PROGRAM)

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.