### PR TITLE
Fix calcium render completion state

### DIFF
--- a/Source/Core/Simulator/EngineController.cpp
+++ b/Source/Core/Simulator/EngineController.cpp
@@ -70,7 +70,7 @@ void SimulationEngineThread(BG::Common::Logger::LoggingSystem* _Logger, Simulati
                 while (_Sim->IsRendering) {
                     std::this_thread::sleep_for(std::chrono::milliseconds(10)); // sleep for 10ms
                 }
-                _Sim->VSDAData_->State_ = VSDA_RENDER_DONE;
+                _Sim->CaData_->State_ = VSDA::Calcium::CA_RENDER_DONE;
                 _Sim->CurrentTask = SIMULATION_NONE;
                 _Sim->WorkRequested = false;
             } else {


### PR DESCRIPTION
Summary:
- mark CaData_ as CA_RENDER_DONE when SIMULATION_CALCIUM completes
- avoid mutating EM VSDAData_ state from the calcium completion path

Verification:
- git diff --check
- source probe confirming EM tasks still set VSDA_RENDER_DONE while calcium tasks set CA_RENDER_DONE
- standalone C++ state probe confirming calcium completion leaves EM state unchanged
- clean patch apply against origin/master
- c++ -std=c++17 -ISource/Core -ISource/Renderer -fsyntax-only Source/Core/Simulator/EngineController.cpp (blocked: missing nlohmann/json.hpp)
- cmake -S . -B /tmp/nes-calcium-engine-state-cmake (blocked: missing ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake and Unix Makefiles build program / CMAKE_MAKE_PROGRAM)

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.