### PR TITLE
Clamp render pool hardware worker counts

### DIFF
--- a/Source/Core/VSDA/RenderPool.cpp
+++ b/Source/Core/VSDA/RenderPool.cpp
@@ -73,10 +73,6 @@ RenderPool::RenderPool(Config::Config* _Config, BG::Common::Logger::LoggingSyste
         _NumThreads = 1;
     #endif
 
-    if (_NumThreads < 1) {
-        _NumThreads = 1;
-    }
-
     unsigned int HardwareThreadCount = std::thread::hardware_concurrency();
     if (HardwareThreadCount == 0) {
         HardwareThreadCount = 1;

--- a/Source/Core/VSDA/RenderPool.cpp
+++ b/Source/Core/VSDA/RenderPool.cpp
@@ -73,19 +73,28 @@ RenderPool::RenderPool(Config::Config* _Config, BG::Common::Logger::LoggingSyste
         _NumThreads = 1;
     #endif
 
+    if (_NumThreads < 1) {
+        _NumThreads = 1;
+    }
+
+    unsigned int HardwareThreadCount = std::thread::hardware_concurrency();
+    if (HardwareThreadCount == 0) {
+        HardwareThreadCount = 1;
+    }
+
     // Setup ConversionPool
-    int NumThreads = float(std::thread::hardware_concurrency()) * 1.5;
+    int NumThreads = static_cast<int>((HardwareThreadCount * 3) / 2);
     EMImageConversionPool_ = std::make_unique<ConversionPool::ConversionPool>(Logger_, NumThreads);
 
 
     // Create VoxelArrayGenerator Instance
-    int NumArrayGeneratorThreads = std::thread::hardware_concurrency();
+    int NumArrayGeneratorThreads = static_cast<int>(HardwareThreadCount);
     EMArrayGeneratorPool_ = std::make_unique<VoxelArrayGenerator::ArrayGeneratorPool>(Logger_, NumArrayGeneratorThreads);
     CalciumArrayGeneratorPool_ = std::make_unique<::BG::NES::VSDA::Calcium::VoxelArrayGenerator::ArrayGeneratorPool>(Logger_, NumArrayGeneratorThreads);
 
 
     // Create ImageProcessorPool Instance
-    int NumEncoderThreads = std::thread::hardware_concurrency();
+    int NumEncoderThreads = static_cast<int>(HardwareThreadCount);
     EMImageProcessorPool_ = std::make_unique<ImageProcessorPool>(Logger_, NumEncoderThreads);
     CalciumImageProcessorPool_ = std::make_unique<::BG::NES::VSDA::Calcium::ImageProcessorPool>(Logger_, NumEncoderThreads);
 


### PR DESCRIPTION
Summary:
- normalize hardware_concurrency() to at least one before sizing conversion, voxel generation, and image processor pools
- reuse the normalized hardware count instead of calling hardware_concurrency() separately for each sub-pool

Verification:
- git diff --check
- source probe confirming the constructor has one hardware_concurrency() call and normalized pool counts
- standalone C++ worker-count probe for hardware counts 0, 1, and 8
- clean patch apply against origin/master
- c++ -std=c++17 -ISource/Core -ISource/Renderer -fsyntax-only Source/Core/VSDA/RenderPool.cpp (blocked: missing BG/Common/Logger/Logger.h)
- cmake -S . -B /tmp/nes-renderpool-worker-fallback-cmake (blocked: missing ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake and Unix Makefiles build program / CMAKE_MAKE_PROGRAM)

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.