### PR TITLE
Report calcium microscope setup status

### DIFF
--- a/Source/Core/VSDA/VSDARPCInterface.cpp
+++ b/Source/Core/VSDA/VSDARPCInterface.cpp
@@ -684,10 +684,14 @@ std::string VSDARPCInterface::VSDACASetupMicroscope(std::string _JSONRequest) {
 
     int Result = !NES::VSDA::Calcium::VSDA_CA_SetupMicroscope(Logger_, Handle.Sim(), Params);
 
-    Handle.Sim()->CaData_->CaImaging.Init(Handle.Sim(), Handle.Sim()->CaData_->Params_);
+    if (Result == 0) {
+        Handle.Sim()->CaData_->CaImaging.Init(Handle.Sim(), Handle.Sim()->CaData_->Params_);
+    }
 
     // Build Response
-    return Handle.ErrResponse();
+    nlohmann::json ResponseJSON;
+    ResponseJSON["StatusCode"] = Result;
+    return ResponseJSON.dump();
 
 }
 std::string VSDARPCInterface::VSDACADefineScanRegion(std::string _JSONRequest) {


### PR DESCRIPTION
Summary:
- return the actual VSDA/Ca/SetupMicroscope setup result in StatusCode
- initialize calcium imaging only after microscope setup succeeds
- match the existing VSDA/EM/SetupMicroscope response shape

Verification:
- git diff --check
- source probe confirming setup success gates CaImaging.Init() and StatusCode uses Result
- standalone C++ setup-response probe for failure and success paths
- clean patch apply against origin/master
- c++ -std=c++17 -ISource/Core -ISource/Renderer -fsyntax-only Source/Core/VSDA/VSDARPCInterface.cpp (blocked: missing cpp-base64/base64.cpp)
- cmake -S . -B /tmp/nes-ca-setup-status-cmake (blocked: missing ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake and Unix Makefiles build program / CMAKE_MAKE_PROGRAM)

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.