### PR TITLE
Clamp visualizer encoder worker count

### DIFF
--- a/Source/Core/Visualizer/VisualizerPool.cpp
+++ b/Source/Core/Visualizer/VisualizerPool.cpp
@@ -79,7 +79,11 @@ VisualizerPool::VisualizerPool(BG::Common::Logger::LoggingSystem* _Logger, bool 
 
 
     // Create ImageProcessorPool Instance
-    int NumEncoderThreads = std::thread::hardware_concurrency();
+    unsigned int HardwareThreadCount = std::thread::hardware_concurrency();
+    if (HardwareThreadCount == 0) {
+        HardwareThreadCount = 1;
+    }
+    int NumEncoderThreads = static_cast<int>(HardwareThreadCount);
     ImageProcessorPool_ = std::make_unique<Visualizer::ImageProcessorPool>(Logger_, NumEncoderThreads);
 
 


### PR DESCRIPTION
Summary:
- normalize visualizer hardware_concurrency() to at least one before creating the image processor pool
- prevent the visualizer encoder pool from starting with zero worker threads when hardware_concurrency() is unavailable

Verification:
- git diff --check
- source probe confirming hardware_concurrency() is normalized before NumEncoderThreads
- standalone C++ worker-count probe for hardware counts 0, 1, and 8
- clean patch apply against origin/master
- c++ -std=c++17 -ISource/Core -ISource/Renderer -fsyntax-only Source/Core/Visualizer/VisualizerPool.cpp (blocked: missing BG/Common/Logger/Logger.h)
- cmake -S . -B /tmp/nes-visualizer-worker-fallback-cmake (blocked: missing ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake and Unix Makefiles build program / CMAKE_MAKE_PROGRAM)

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.