### PR TITLE
Use configured igneous parallel jobs

### DIFF
--- a/Source/Core/VSDA/EM/NeuroglancerConversionPool/IgneousPipeline.cpp
+++ b/Source/Core/VSDA/EM/NeuroglancerConversionPool/IgneousPipeline.cpp
@@ -43,6 +43,9 @@ bool ProcessIgneousPipeline(BG::Common::Logger::LoggingSystem* _Logger,
     int mipLevel,
     int parallelJobs,
     const std::string& pythonVenv) {
+if (parallelJobs < 1) {
+parallelJobs = 1;
+}
 _Logger->Log("Starting Igneous processing pipeline", 3);
 _Logger->Log("Parameters:", 4);
 _Logger->Log("- Dataset path: " + datasetPath, 4);
@@ -69,7 +72,10 @@ const std::string queuePath = (absOutputDir / "queue").string();
 const std::string igneousBin = "\"" + absPythonVenv.string() + "/bin/igneous\"";
 
 //std::system((std::string("bash /home/rkoene/src/igneous_calls.sh ")+absDatasetPath.string()+" 0 60").c_str());
-std::system(("bash "+absPythonVenv.string()+"/bin/activate && python3 ./Python/igneous_local.py --datapath "+absDatasetPath.string()+" --parallel 60").c_str());
+const std::string igneousCommand = "bash " + absPythonVenv.string() + "/bin/activate && "
+    "python3 ./Python/igneous_local.py --datapath " + absDatasetPath.string() +
+    " --parallel " + std::to_string(parallelJobs);
+std::system(igneousCommand.c_str());
 return true;
 // pid_t pid = fork();
 // if (pid == 0) {


### PR DESCRIPTION
Summary:
- use the ProcessIgneousPipeline parallelJobs argument when building the igneous local command
- clamp nonpositive parallelJobs values to one before logging and execution
- remove the hard-coded --parallel 60 command argument

Verification:
- git diff --check
- source probe confirming --parallel uses std::to_string(parallelJobs) and the hard-coded value is gone
- standalone C++ command probe for parallelJobs 0, -4, and 8
- clean patch apply against origin/master
- c++ -std=c++17 -ISource/Core -ISource/Renderer -fsyntax-only Source/Core/VSDA/EM/NeuroglancerConversionPool/IgneousPipeline.cpp (blocked: missing BG/Common/Logger/Logger.h)
- cmake -S . -B /tmp/nes-igneous-parallel-jobs-cmake (blocked: missing ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake and Unix Makefiles build program / CMAKE_MAKE_PROGRAM)

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.