### PR TITLE
Clamp zero worker pool thread counts

### DIFF
--- a/Source/Core/VSDA/Ca/VoxelSubsystem/ArrayGeneratorPool/ArrayGeneratorPool.cpp
+++ b/Source/Core/VSDA/Ca/VoxelSubsystem/ArrayGeneratorPool/ArrayGeneratorPool.cpp
@@ -130,6 +130,11 @@ ArrayGeneratorPool::ArrayGeneratorPool(BG::Common::Logger::LoggingSystem* _Logge
         _NumThreads = 1;
     #endif
 
+    // cppcheck-suppress knownConditionTrueFalse
+    if (_NumThreads == 0) {
+        _NumThreads = 1;
+    }
+
 
     // Create Renderer Instances
     Logger_->Log("Creating CAArrayGeneratorPool With " + std::to_string(_NumThreads) + " Thread(s)", 2);

--- a/Source/Core/VSDA/Ca/VoxelSubsystem/ImageProcessorPool/ImageProcessorPool.cpp
+++ b/Source/Core/VSDA/Ca/VoxelSubsystem/ImageProcessorPool/ImageProcessorPool.cpp
@@ -251,6 +251,11 @@ ImageProcessorPool::ImageProcessorPool(BG::Common::Logger::LoggingSystem* _Logge
         _NumThreads = 1;
     #endif
 
+    // cppcheck-suppress knownConditionTrueFalse
+    if (_NumThreads == 0) {
+        _NumThreads = 1;
+    }
+
     // Create Renderer Instances
     Logger_->Log("Creating CAImageProcessorPool With " + std::to_string(_NumThreads) + " Thread(s)", 2);
     for (unsigned int i = 0; i < _NumThreads; i++) {

--- a/Source/Core/VSDA/EM/NeuroglancerConversionPool/ConversionPool/ConversionPool.cpp
+++ b/Source/Core/VSDA/EM/NeuroglancerConversionPool/ConversionPool/ConversionPool.cpp
@@ -203,6 +203,11 @@ ConversionPool::ConversionPool(BG::Common::Logger::LoggingSystem* _Logger, int _
         _NumThreads = 1;
     #endif
 
+    // cppcheck-suppress knownConditionTrueFalse
+    if (_NumThreads == 0) {
+        _NumThreads = 1;
+    }
+
 
     // Create Renderer Instances
     Logger_->Log("Creating EMConversionPool With " + std::to_string(_NumThreads) + " Thread(s)", 2);

--- a/Source/Core/VSDA/EM/VoxelSubsystem/ArrayGeneratorPool/ArrayGeneratorPool.cpp
+++ b/Source/Core/VSDA/EM/VoxelSubsystem/ArrayGeneratorPool/ArrayGeneratorPool.cpp
@@ -163,6 +163,11 @@ ArrayGeneratorPool::ArrayGeneratorPool(BG::Common::Logger::LoggingSystem* _Logge
         _NumThreads = 1;
     #endif
 
+    // cppcheck-suppress knownConditionTrueFalse
+    if (_NumThreads == 0) {
+        _NumThreads = 1;
+    }
+
     // Create Renderer Instances
     Logger_->Log("Creating EMArrayGeneratorPool With " + std::to_string(_NumThreads) + " Thread(s)", 2);
     for (unsigned int i = 0; i < _NumThreads; i++) {

--- a/Source/Core/VSDA/EM/VoxelSubsystem/ImageProcessorPool/ImageProcessorPool.cpp
+++ b/Source/Core/VSDA/EM/VoxelSubsystem/ImageProcessorPool/ImageProcessorPool.cpp
@@ -479,6 +479,11 @@ ImageProcessorPool::ImageProcessorPool(BG::Common::Logger::LoggingSystem* _Logge
         _NumThreads = 1;
     #endif
 
+    // cppcheck-suppress knownConditionTrueFalse
+    if (_NumThreads == 0) {
+        _NumThreads = 1;
+    }
+
     // Create Renderer Instances
     Logger_->Log("Creating EMImageProcessorPool With " + std::to_string(_NumThreads) + " Thread(s)", 2);
     for (unsigned int i = 0; i < _NumThreads; i++) {

--- a/Source/Core/Visualizer/ImageProcessorPool/ImageProcessorPool.cpp
+++ b/Source/Core/Visualizer/ImageProcessorPool/ImageProcessorPool.cpp
@@ -140,6 +140,11 @@ ImageProcessorPool::ImageProcessorPool(BG::Common::Logger::LoggingSystem* _Logge
         _NumThreads = 1;
     #endif
 
+    // cppcheck-suppress knownConditionTrueFalse
+    if (_NumThreads == 0) {
+        _NumThreads = 1;
+    }
+
 
     // Create Renderer Instances
     Logger_->Log("Creating VisualizerImageProcessorPool With " + std::to_string(_NumThreads) + " Thread(s)", 2);


### PR DESCRIPTION
I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Summary
- Clamp zero thread counts to one in visualizer, EM, and calcium worker pool constructors
- Avoid zero-worker pools when callers pass through an unavailable hardware-concurrency result

## Verification
- git diff --check
- standalone C++17 normalization probe for counts 0, 1, and 6
- clean patch apply against fresh origin/master
- attempted fsyntax-only checks; blocked by missing vendored `stb_image.h`
- attempted CMake configure; blocked by missing `ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake` and unset `CMAKE_MAKE_PROGRAM`