### PR TITLE
Fix TruncNorm instance parameter caching

### DIFF
--- a/Source/Core/Simulator/Distributions/TruncNorm.cpp
+++ b/Source/Core/Simulator/Distributions/TruncNorm.cpp
@@ -88,9 +88,9 @@ float TruncNorm::PDF(float x) {
     if (x < this->a || x > this->b)
         return 0.0;
 
-    static float z_a = (this->a - this->loc) / this->scale;
-    static float z_b = (this->b - this->loc) / this->scale;
-    static float Z = _StandardNormalCDF(z_b) - _StandardNormalCDF(z_a);
+    float z_a = (this->a - this->loc) / this->scale;
+    float z_b = (this->b - this->loc) / this->scale;
+    float Z = _StandardNormalCDF(z_b) - _StandardNormalCDF(z_a);
 
     float z_x = (x - this->loc) / this->scale;
     return _StandardNormalPDF(z_x) / (this->scale * Z);
@@ -112,9 +112,9 @@ float TruncNorm::CDF(float x) {
     if (x > b)
         return 1.0;
 
-    static float z_a = (this->a - this->loc) / this->scale;
-    static float z_b = (this->b - this->loc) / this->scale;
-    static float Z = _StandardNormalCDF(z_b) - _StandardNormalCDF(z_a);
+    float z_a = (this->a - this->loc) / this->scale;
+    float z_b = (this->b - this->loc) / this->scale;
+    float Z = _StandardNormalCDF(z_b) - _StandardNormalCDF(z_a);
 
     float z_x = (x - this->loc) / this->scale;
 
@@ -129,10 +129,10 @@ std::tuple<float, float> TruncNorm::Stats() {
 
 //! Mean
 float TruncNorm::Mean() {
-    static float z_a = (this->a - this->loc) / this->scale;
-    static float z_b = (this->b - this->loc) / this->scale;
-    static float Z = _StandardNormalCDF(z_b) - _StandardNormalCDF(z_a);
-    static float mean =
+    float z_a = (this->a - this->loc) / this->scale;
+    float z_b = (this->b - this->loc) / this->scale;
+    float Z = _StandardNormalCDF(z_b) - _StandardNormalCDF(z_a);
+    float mean =
         this->loc +
         (_StandardNormalPDF(z_a) - _StandardNormalPDF(z_b)) * this->scale / Z;
 
@@ -141,13 +141,13 @@ float TruncNorm::Mean() {
 
 //! Standard deviation
 float TruncNorm::Std() {
-    static float z_a = (this->a - this->loc) / this->scale;
-    static float z_b = (this->b - this->loc) / this->scale;
-    static float Z = _StandardNormalCDF(z_b) - _StandardNormalCDF(z_a);
-    static float pdf_z_a = _StandardNormalPDF(z_a);
-    static float pdf_z_b = _StandardNormalPDF(z_b);
+    float z_a = (this->a - this->loc) / this->scale;
+    float z_b = (this->b - this->loc) / this->scale;
+    float Z = _StandardNormalCDF(z_b) - _StandardNormalCDF(z_a);
+    float pdf_z_a = _StandardNormalPDF(z_a);
+    float pdf_z_b = _StandardNormalPDF(z_b);
 
-    static float sigma =
+    float sigma =
         this->scale * sqrt(1 - (z_b * pdf_z_b - z_a * pdf_z_a) / Z -
                            pow((pdf_z_a - pdf_z_b) / Z, 2.0));
 

--- a/Source/Core/Simulator/Distributions/TruncNorm.test.cpp
+++ b/Source/Core/Simulator/Distributions/TruncNorm.test.cpp
@@ -82,3 +82,17 @@ TEST_F( TruncNormTest, test_Std_default ) {
     
     ASSERT_NEAR(std, 0.4787, tol);
 }
+
+TEST_F( TruncNormTest, test_InstanceSpecificParameters ) {
+    testTruncNorm->PDF(1.0f);
+    testTruncNorm->CDF(1.0f);
+    testTruncNorm->Mean();
+    testTruncNorm->Std();
+
+    BG::NES::Simulator::Distributions::TruncNorm shiftedTruncNorm(1.0f, 5.0f, 3.0f, 0.5f);
+
+    ASSERT_NEAR(shiftedTruncNorm.PDF(3.0f), 0.7979, tol);
+    ASSERT_NEAR(shiftedTruncNorm.CDF(3.0f), 0.5, tol);
+    ASSERT_NEAR(shiftedTruncNorm.Mean(), 3.0, tol);
+    ASSERT_NEAR(shiftedTruncNorm.Std(), 0.4997, tol);
+}


### PR DESCRIPTION
I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Summary
- Recompute TruncNorm normalization constants from the current instance instead of caching the first instance in static locals
- Add a regression test that evaluates a default distribution before a differently parameterized distribution

## Verification
- git diff --check
- focused C++17 executable linking TruncNorm.cpp and Distribution.cpp, covering PDF/CDF/Mean/Std across two instances
- clean patch apply against fresh origin/master
- attempted TruncNorm.test.cpp syntax check; blocked by missing `gtest/gtest.h`
- attempted CMake configure; blocked by missing `ThirdParty/vcpkg/scripts/buildsystems/vcpkg.cmake` and unset `CMAKE_MAKE_PROGRAM`