### PR TITLE
Guard calcium kernel timing edge cases

### DIFF
--- a/Source/Core/Simulator/Structs/CalciumImaging.cpp
+++ b/Source/Core/Simulator/Structs/CalciumImaging.cpp
@@ -91,6 +91,12 @@ void CalciumImaging::InitializeFluorescenceKernel(Simulation* _Sim, NES::VSDA::C
         v_sum += k;
         t += _Sim->Dt_ms;
     }
+    if (FluorescenceKernel.empty() || ((v_sum > -0.000001F) && (v_sum < 0.000001F))) {
+        FluorescenceKernel.clear();
+        FluorescenceKernel.emplace_back(1.0F);
+        ReversedFluorescenceKernel.assign(1, 1.0F);
+        return;
+    }
     // Scale and reverse the kernel:
     size_t kernelsize = FluorescenceKernel.size();
     ReversedFluorescenceKernel.resize(kernelsize, 0.0);
@@ -108,6 +114,10 @@ void CalciumImaging::InitializeFluorescingNeuronFIFOs(Simulation* _Sim, NES::VSD
     // *** TODO: Set different FIFO sizes for different GCaMP types.
     float FIFO_ms = 4.0 * (_Params.IndicatorRiseTime_ms + _Params.IndicatorDecayTime_ms);
     float FIFO_dt_ms = _Sim->Dt_ms;
+    if (FIFO_dt_ms > 0.0F) {
+        float MinFIFO_ms = 9.0F * FIFO_dt_ms;
+        if (FIFO_ms < MinFIFO_ms) FIFO_ms = MinFIFO_ms;
+    }
     if (_Params.FlourescingNeuronIDs_.empty()) {
         // All neurons.
         for (auto & neuron_ptr : _Sim->Neurons) {

--- a/Source/Core/Simulator/Structs/SignalFunctions.cpp
+++ b/Source/Core/Simulator/Structs/SignalFunctions.cpp
@@ -11,6 +11,7 @@ float DoubleExponentExpr(float amp, float tauRise, float tauDecay, float tDiff) 
     assert(tauRise >= 0.0 && tauDecay >= 0.0);
 
     if (tDiff < 0) return 0.0;
+    if ((tauRise <= 0.0F) || (tauDecay <= 0.0F)) return 0.0F;
 
     return amp * (-exp(-tDiff / tauRise) + exp(-tDiff / tauDecay));
 }


### PR DESCRIPTION
## Summary
- avoid division by zero in `DoubleExponentExpr()` for nonpositive calcium indicator time constants
- fall back to a normalized one-sample fluorescence kernel when indicator timing produces an empty or zero-sum kernel
- clamp calcium FIFO duration to enough samples for the existing convolution offset when timing values are degenerate

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- git diff --check
- c++ -std=c++17 -ISource/Core -fsyntax-only Source/Core/Simulator/Structs/SignalFunctions.cpp
- focused source probe confirming nonpositive tau guard, zero-sum kernel fallback, unit reversed kernel, and FIFO minimum clamp
- standalone C++17 kernel/FIFO probe covering zero rise/decay, equal rise/decay, negative sample offsets, and normal normalized kernels
- clean patch apply against origin/master
- attempted c++ -std=c++17 -ISource/Core -fsyntax-only Source/Core/Simulator/Structs/CalciumImaging.cpp (blocked: missing nlohmann/json.hpp through Simulation.h)
- attempted cd Tools && bash Build.sh 6 Release (blocked: existing local build has no CMAKE_MAKE_PROGRAM/build tool, reporting permission denied / empty build command)