### PR TITLE
Clamp EM voxel render step sizes

### DIFF
--- a/Source/Core/VSDA/EM/VoxelSubsystem/VoxelArrayRenderer.cpp
+++ b/Source/Core/VSDA/EM/VoxelSubsystem/VoxelArrayRenderer.cpp
@@ -51,15 +51,27 @@ int RenderSliceFromArray(BG::Common::Logger::LoggingSystem* _Logger, int MaxImag
     // In order for us to deal with multiple different pixel/voxel setting, we create an image of start size where one pixel = 1 voxel
     // then later on, we resample it to be the right size (for the target image)
     // The number of voxels we move per step depends on image size and overlap percentage:
-    int ImageWidth_vox = ceil(_VSDAData->Params_.ImageWidth_px / _VSDAData->Params_.NumPixelsPerVoxel_px);
-    int ImageHeight_vox = ceil(_VSDAData->Params_.ImageHeight_px / _VSDAData->Params_.NumPixelsPerVoxel_px);
-    int VoxelsPerStepX = ceil(_VSDAData->Params_.ImageWidth_px * (1. - (_VSDAData->Params_.ScanRegionOverlap_percent / 100.)) / _VSDAData->Params_.NumPixelsPerVoxel_px);
-    int VoxelsPerStepY = ceil(_VSDAData->Params_.ImageHeight_px * (1. - (_VSDAData->Params_.ScanRegionOverlap_percent / 100.)) / _VSDAData->Params_.NumPixelsPerVoxel_px);
-    int VoxelsOverlapX = ceil(_VSDAData->Params_.ImageWidth_px * (_VSDAData->Params_.ScanRegionOverlap_percent / 100.) / _VSDAData->Params_.NumPixelsPerVoxel_px);
-    int VoxelsOverlapY = ceil(_VSDAData->Params_.ImageHeight_px * (_VSDAData->Params_.ScanRegionOverlap_percent / 100.) / _VSDAData->Params_.NumPixelsPerVoxel_px);
+    int PixelsPerVoxel = _VSDAData->Params_.NumPixelsPerVoxel_px;
+    if (PixelsPerVoxel < 1) PixelsPerVoxel = 1;
+    float OverlapRatio = _VSDAData->Params_.ScanRegionOverlap_percent / 100.0F;
+    if (OverlapRatio < 0.0F) OverlapRatio = 0.0F;
+    if (OverlapRatio >= 1.0F) OverlapRatio = 0.99F;
+    float StepRatio = 1.0F - OverlapRatio;
+    int ImageWidth_vox = ceil(static_cast<float>(_VSDAData->Params_.ImageWidth_px) / PixelsPerVoxel);
+    int ImageHeight_vox = ceil(static_cast<float>(_VSDAData->Params_.ImageHeight_px) / PixelsPerVoxel);
+    int VoxelsPerStepX = ceil(_VSDAData->Params_.ImageWidth_px * StepRatio / PixelsPerVoxel);
+    int VoxelsPerStepY = ceil(_VSDAData->Params_.ImageHeight_px * StepRatio / PixelsPerVoxel);
+    if (ImageWidth_vox < 1) ImageWidth_vox = 1;
+    if (ImageHeight_vox < 1) ImageHeight_vox = 1;
+    if (VoxelsPerStepX < 1) VoxelsPerStepX = 1;
+    if (VoxelsPerStepY < 1) VoxelsPerStepY = 1;
     int NumChannels = 3;
     float CameraStepSizeX_um = VoxelsPerStepX * _VSDAData->Params_.VoxelResolution_um;
     float CameraStepSizeY_um = VoxelsPerStepY * _VSDAData->Params_.VoxelResolution_um;
+    if ((CameraStepSizeX_um <= 0.0F) || (CameraStepSizeY_um <= 0.0F)) {
+        _Logger->Log("Cannot render EM voxel array with nonpositive camera step size", 7);
+        return 0;
+    }
 
     double TotalSliceWidth = abs((double)Array->GetBoundingBox().bb_point1[0] - (double)Array->GetBoundingBox().bb_point2[0]);
     double TotalSliceHeight = abs((double)Array->GetBoundingBox().bb_point1[1] - (double)Array->GetBoundingBox().bb_point2[1]);


### PR DESCRIPTION
## Summary
- clamp pixels-per-voxel to avoid zero divisors in EM slice rendering
- bound scan overlap before calculating voxel step sizes
- clamp image and step voxels to at least one and skip rendering when camera step size is still nonpositive

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- git diff --check
- focused source probe confirming pixel-per-voxel clamp, overlap bounds, image/step voxel clamps, camera-step guard, and removal of unused overlap temps
- standalone C++17 arithmetic probe covering 100% overlap, negative overlap, zero pixels-per-voxel, zero/negative image sizes, and zero voxel resolution
- clean patch apply against origin/master
- attempted c++ -std=c++17 -ISource/Core -ISource/Renderer -fsyntax-only Source/Core/VSDA/EM/VoxelSubsystem/VoxelArrayRenderer.cpp (blocked: missing BG/Common/Logger/Logger.h in local include path)
- attempted cd Tools && bash Build.sh 6 Release (blocked: existing local build has no CMAKE_MAKE_PROGRAM/build tool, reporting permission denied / empty build command)