### PR TITLE
Let NES SafeClient exit while waiting for config

### DIFF
--- a/Source/Core/RPC/SafeClient.cpp
+++ b/Source/Core/RPC/SafeClient.cpp
@@ -67,9 +67,15 @@ bool SafeClient::Connect() {
     Client_ = nullptr;
 
     // Extract RPC Service Client Parameters, Connect, Configure
-    std::string NESHost = RPCHost_;
-    int NESPort = RPCPort_;
-    int NESTimeout_ms = RPCTimeout_ms;
+    std::string NESHost;
+    int NESPort;
+    int NESTimeout_ms;
+    {
+        std::lock_guard<std::mutex> Lock(ConfigMutex_);
+        NESHost = RPCHost_;
+        NESPort = RPCPort_;
+        NESTimeout_ms = RPCTimeout_ms;
+    }
     
     Logger_->Log("Connecting to RPC Service on port: " + std::to_string(NESPort), 1);
     Logger_->Log("Connecting to RPC Service on host: " + NESHost, 1);
@@ -97,21 +103,26 @@ bool SafeClient::Connect() {
 SafeClient::SafeClient(BG::Common::Logger::LoggingSystem* _Logger) {
 
     Logger_ = _Logger;
-    RequestExit_ = false;
+    IsHealthy_.store(false);
+    RequestExit_.store(false);
     ClientManager_ = std::thread(&SafeClient::RPCManagerThread, this);
 
 }
 
 SafeClient::~SafeClient() {
-    RequestExit_ = true;
-    ClientManager_.join();
+    RequestExit_.store(true);
+    if (ClientManager_.joinable()) {
+        ClientManager_.join();
+    }
 }
 
 bool SafeClient::SetTimeout(int _Timeout_ms) {
+    std::lock_guard<std::mutex> Lock(ConfigMutex_);
     RPCTimeout_ms = _Timeout_ms;
     return true;
 }
 bool SafeClient::SetHostPort(std::string _Host, int _Port) {
+    std::lock_guard<std::mutex> Lock(ConfigMutex_);
     RPCHost_ = _Host;
     RPCPort_ = _Port;
     return true;
@@ -164,13 +175,22 @@ bool SafeClient::MakeJSONQuery(std::string _Route, std::string _Query, std::stri
 void SafeClient::RPCManagerThread() {
 
     // Wait Until Config Valid
-    while (RPCHost_ == "") {
+    while (!RequestExit_.load()) {
+        {
+            std::lock_guard<std::mutex> Lock(ConfigMutex_);
+            if (RPCHost_ != "") {
+                break;
+            }
+        }
         std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    }
+    if (RequestExit_.load()) {
+        return;
     }
 
 
     // Enter loop
-    while (!RequestExit_) {
+    while (!RequestExit_.load()) {
 
         // Check Version
         bool IsHealthy = RunVersionCheck();

--- a/Source/Core/RPC/SafeClient.h
+++ b/Source/Core/RPC/SafeClient.h
@@ -13,6 +13,8 @@
 // Standard Libraries (BG convention: use <> instead of "")
 #include <iostream>
 #include <memory>
+// cppcheck-suppress missingIncludeSystem
+#include <mutex>
 
 // Third-Party Libraries (BG convention: use <> instead of "")
 #include <rpc/client.h>
@@ -43,6 +45,7 @@ private:
     BG::Common::Logger::LoggingSystem* Logger_ = nullptr; /**Pointer to the instance of the logging system*/
 
     std::thread ClientManager_; /**Thread that owns the client, and autoreconnects, etc.*/
+    std::mutex ConfigMutex_; /**Protects host, port, and timeout settings shared with the manager thread*/
 
     bool LastState_ = false;
 


### PR DESCRIPTION
## Summary
- make the SafeClient manager thread respect `RequestExit_` while waiting for host configuration
- guard manager thread joins with `joinable()`
- protect host, port, and timeout settings with a mutex while copying them into connection attempts

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- git diff --check
- focused source probe confirming config mutex use, atomic exit stores/loads, exit-aware config wait, and joinable destructor guard
- standalone C++17 SafeClient-style shutdown probe covering destructor before host configuration and after host configuration
- clean patch apply against origin/master
- attempted c++ -std=c++17 -ISource/Core -fsyntax-only Source/Core/RPC/SafeClient.cpp (blocked: missing rpc/rpc_error.h in local checkout)
- attempted cd Tools && bash Build.sh 6 Release (blocked: existing local build has no CMAKE_MAKE_PROGRAM/build tool, reporting permission denied / empty build command)