### PR TITLE
Fix calcium render Y image count

### DIFF
--- a/Source/Core/VSDA/Ca/CaRenderer.cpp
+++ b/Source/Core/VSDA/Ca/CaRenderer.cpp
@@ -99,7 +99,7 @@ bool ExecuteCaSubRenderOperations(BG::Common::Logger::LoggingSystem* _Logger, Si
     double ImageStepSizeX_um = (Params->ImageWidth_px / Params->NumPixelsPerVoxel_px) * Params->VoxelResolution_um * (1 - (double(Params->ScanRegionOverlap_percent) / 100.));
     double ImageStepSizeY_um = (Params->ImageHeight_px / Params->NumPixelsPerVoxel_px) * Params->VoxelResolution_um * (1 - (double(Params->ScanRegionOverlap_percent) / 100.));
     int NumImagesInXDimension_img = ceil(BaseRegion->SizeX() / ImageStepSizeX_um);
-    int NumImagesInYDimension_img = ceil(BaseRegion->SizeX() / ImageStepSizeY_um);
+    int NumImagesInYDimension_img = ceil(BaseRegion->SizeY() / ImageStepSizeY_um);
 
     // Nextly, we're going to figure out the step size information for the subregions.
     // This will enable us to create subregions that exactly are multiples of the image step sizes, removing any overlap (unless it's on the border, then it may overshoot slightly)


### PR DESCRIPTION
## Summary
- compute calcium render Y image count from the scan region Y size instead of the X size
- preserve the existing X count and subregion calculations otherwise

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- git diff --check
- source probe confirming NumImagesInYDimension_img uses BaseRegion->SizeY()
- standalone C++17 arithmetic probe for non-square calcium scan regions
- clean patch apply against origin/master in a detached worktree
- c++ -std=c++17 -ISource/Core -ISource/Renderer -fsyntax-only Source/Core/VSDA/Ca/CaRenderer.cpp (blocked by existing missing nlohmann/json.hpp)
- cd Tools && bash Build.sh 6 Release (blocked by existing local build tool state: permission denied / empty Makefile command)