### PR TITLE
Guard box slice bounds

### DIFF
--- a/Source/Core/Simulator/Geometries/Box.cpp
+++ b/Source/Core/Simulator/Geometries/Box.cpp
@@ -42,7 +42,12 @@ std::vector<std::vector<float>> Box::EqualSliceBounds(int nSlices, int slice) {
     std::vector<float> bottomRight = {0.0, 0.0, 0.0};
     float pWidth = 0.0, y0 = 0.0;
 
-    assert(slice <= nSlices);
+    assert(nSlices > 0);
+    assert(slice >= 0);
+    assert(slice < nSlices);
+    if (nSlices <= 0 || slice < 0 || slice >= nSlices) {
+        return {topLeft, bottomRight};
+    }
 
     pWidth = this->Dims_um.y / nSlices;
     y0 = this->Center_um.y - this->Dims_um.y / 2.0;

--- a/Source/Core/Simulator/Geometries/Box.test.cpp
+++ b/Source/Core/Simulator/Geometries/Box.test.cpp
@@ -61,6 +61,16 @@ TEST_F( BoxTest, test_EqualSliceBounds_default ) {
     ASSERT_TRUE((bottomRight[1] >= minY) && (bottomRight[1] <= maxY)) << "Bottom right y coordinate = " << bottomRight[1];
 }
 
+TEST_F( BoxTest, test_EqualSliceBounds_last_slice ) {
+    int nSlices = 10;
+    std::vector<std::vector<float>> gotBounds = testBox->EqualSliceBounds(nSlices, nSlices - 1);
+    std::vector<float> topLeft = gotBounds[0];
+    std::vector<float> bottomRight = gotBounds[1];
+
+    ASSERT_TRUE((topLeft[1] >= minY) && (topLeft[1] <= maxY)) << "Top left y coordinate = " << topLeft[1];
+    ASSERT_NEAR(bottomRight[1], maxY, tol) << "Bottom right y coordinate = " << bottomRight[1];
+}
+
 TEST_F( BoxTest, test_Sides_default ) {
     std::vector<float> gotSides = testBox->Sides();
 


### PR DESCRIPTION
## Summary
- require positive slice counts and zero-based slice indexes below nSlices in Box::EqualSliceBounds
- return zero bounds for invalid arguments in release builds instead of dividing by zero or returning a slice past the box
- add a last-valid-slice unit test that verifies the Y bound ends at the box maximum

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- git diff --check
- source probe confirming stricter asserts, release guard, and last-slice test
- standalone C++17 arithmetic probe built with -DNDEBUG covering first slice, last slice, slice == nSlices, and nSlices == 0
- clean patch apply against origin/master in a detached worktree
- c++ -std=c++17 -ISource/Core -ISource/Renderer -fsyntax-only Source/Core/Simulator/Geometries/Box.cpp (blocked by existing missing BG/Common/Logger/Logger.h)
- c++ -std=c++17 -ISource/Core -ISource/Renderer -fsyntax-only Source/Core/Simulator/Geometries/Box.test.cpp (blocked by missing gtest/gtest.h)
- cd Tools && bash Build.sh 6 Release (blocked by existing local build tool state: permission denied / empty Makefile command)