### PR TITLE
Ensure voxel generator queues tiny shapes

### DIFF
--- a/Source/Core/VSDA/EM/VoxelSubsystem/VoxelArrayGenerator.cpp
+++ b/Source/Core/VSDA/EM/VoxelSubsystem/VoxelArrayGenerator.cpp
@@ -175,6 +175,9 @@ bool CreateVoxelArrayFromSimulation(BG::Common::Logger::LoggingSystem* _Logger, 
 
                 // subdivide the cylinder into segments until it's shorter than the threshold number of voxels
                 int NumSegments = ceil(double(EstimatedSize_vox) / double(SubdivisionThreshold_vox));
+                if (NumSegments < 1) {
+                    NumSegments = 1;
+                }
                 // _Logger->Log("Detected Sphere of Size " + std::to_string(EstimatedSize_vox) + "vox, Subdividing Into " + std::to_string(NumSegments) + " Segments", 2);
 
 
@@ -241,6 +244,9 @@ bool CreateVoxelArrayFromSimulation(BG::Common::Logger::LoggingSystem* _Logger, 
 
                 // subdivide the cylinder into segments until it's shorter than the threshold number of voxels
                 int NumSegments = ceil(double(EstimatedSize_vox) / double(SubdivisionThreshold_vox));
+                if (NumSegments < 1) {
+                    NumSegments = 1;
+                }
                 // _Logger->Log("Detected Cylinder of Size " + std::to_string(EstimatedSize_vox) + "vox, Subdividing Into " + std::to_string(NumSegments) + " Segments", 2);
                 // std::vector<Geometries::Vec3D> PointList = SubdivideLine(ThisCylinder.End0Pos_um, ThisCylinder.End1Pos_um, NumSegments);
 


### PR DESCRIPTION
## Summary
- clamp sphere and cylinder subdivision counts to at least one segment
- prevent tiny nonzero shapes with a zero voxel estimate from being skipped by zero-iteration task loops

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Testing
- source probe confirming both NumSegments calculations clamp values below one
- standalone C++17 segment-count probe for zero, sub-threshold, threshold, and above-threshold estimates
- git diff --check origin/master
- clean origin/master worktree patch apply with git apply --check --whitespace=error-all
- c++ -std=c++17 -ISource/Core -ISource/Renderer -fsyntax-only Source/Core/VSDA/EM/VoxelSubsystem/VoxelArrayGenerator.cpp (blocked locally: missing BG/Common/Logger/Logger.h)
- bash Build.sh 6 Release from Tools (blocked locally: CMake build tool command is empty / permission denied)