### PR TITLE
Validate NES config required keys

### DIFF
--- a/Source/Core/Config/ConfigFileParser.cpp
+++ b/Source/Core/Config/ConfigFileParser.cpp
@@ -44,11 +44,30 @@ ConfigFileParser::ConfigFileParser(Config &_Config) {
 
 
     // Populate Configuration Struct With Data From Configuration File
-    _Config.PortNumber = Config["Network_NES_API_Port"].as<int>();
-    _Config.Host = Config["Network_NES_API_Host"].as<std::string>();
+    auto ReportInvalidConfigAndExit = [&](const std::string &Message) {
+        std::cerr<<"[FATAL], Invalid Config File: "<<Message<<"\n";
+        exit(1);
+    };
 
-    _Config.MaxVoxelArraySize_ = Config["VSDA_EM_MaxVoxelArraySize"].as<int>();
-    _Config.VoxelArrayPercentOfSystemMemory_ = Config["VSDA_EM_PercentOfSysteMemoryLimit"].as<int>();
+    auto RequireConfigKey = [&](const std::string &Key) {
+        if (!Config[Key]) {
+            ReportInvalidConfigAndExit("Missing required key " + Key);
+        }
+    };
+
+    try {
+        RequireConfigKey("Network_NES_API_Port");
+        RequireConfigKey("Network_NES_API_Host");
+        RequireConfigKey("VSDA_EM_MaxVoxelArraySize");
+        RequireConfigKey("VSDA_EM_PercentOfSysteMemoryLimit");
+
+        _Config.PortNumber = Config["Network_NES_API_Port"].as<int>();
+        _Config.Host = Config["Network_NES_API_Host"].as<std::string>();
+        _Config.MaxVoxelArraySize_ = Config["VSDA_EM_MaxVoxelArraySize"].as<int>();
+        _Config.VoxelArrayPercentOfSystemMemory_ = Config["VSDA_EM_PercentOfSysteMemoryLimit"].as<float>();
+    } catch(const YAML::Exception& e) {
+        ReportInvalidConfigAndExit(e.what());
+    }
 
 }
 


### PR DESCRIPTION
## Summary
- validate required NES config keys before converting YAML values
- catch YAML conversion errors and route them through the existing fatal config startup path
- parse the VSDA memory percentage as a float to match the configuration struct

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- `git diff --check`
- focused C++17 control-flow probe for valid, missing-key, and wrong-type config values
- clean patch apply against a fresh `origin/master` clone
- direct syntax check blocked locally by missing `yaml-cpp/yaml.h`
- `cd Tools && bash Build.sh 6 Release` remains blocked locally by the known empty/permission-denied Make command