### PR TITLE
Guard bounding box voxel scale

### DIFF
--- a/Source/Core/Simulator/Structs/BoundingBox.cpp
+++ b/Source/Core/Simulator/Structs/BoundingBox.cpp
@@ -107,6 +107,10 @@ bool BoundingBox::IsIntersecting(BoundingBox _Box) {
 
 uint64_t BoundingBox::GetVoxelSize(float _VoxelScale_um) {
 
+    if (_VoxelScale_um <= 0.0F) {
+        return 0;
+    }
+
     float SizeX = abs(bb_point1[0] - bb_point2[0]);
     float SizeY = abs(bb_point1[1] - bb_point2[1]);
     float SizeZ = abs(bb_point1[2] - bb_point2[2]);


### PR DESCRIPTION
## Summary
- return a zero voxel estimate when `BoundingBox::GetVoxelSize()` receives a nonpositive voxel scale
- preserve existing positive-scale and reversed-point dimension behavior

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- `git diff --check`
- direct `BoundingBox.cpp` C++17 syntax check
- focused C++17 arithmetic probe for positive, zero, negative, and reversed-point bounding boxes
- clean patch apply against a fresh `origin/master` clone
- `cd Tools && bash Build.sh 6 Release` remains blocked locally by the known empty/permission-denied Make command