### PR TITLE
Guard scan region voxel scale

### DIFF
--- a/Source/Core/VSDA/Common/Structs/ScanRegion.cpp
+++ b/Source/Core/VSDA/Common/Structs/ScanRegion.cpp
@@ -35,6 +35,10 @@ std::string ScanRegion::ToString() {
 }
 
 std::string ScanRegion::GetDimensionsInVoxels(float _VoxelScale_um) {
+    if (_VoxelScale_um <= 0.0F) {
+        return "0XVox, 0YVox, 0ZVox";
+    }
+
     float SizeX = fabs(Point1X_um - Point2X_um); // apparently abs *only* returns an int!!!!! WTF!>!:??!?!?! WHY DO I HAVE TO USE fabs INSTEAD?>!?!?!?!!
     float SizeY = fabs(Point1Y_um - Point2Y_um);
     float SizeZ = fabs(Point1Z_um - Point2Z_um);
@@ -65,6 +69,10 @@ double ScanRegion::SizeZ() {
 
 
 uint64_t ScanRegion::GetVoxelSize(float _VoxelScale_um) {
+    if (_VoxelScale_um <= 0.0F) {
+        return 0;
+    }
+
     float SizeX = fabs(Point1X_um - Point2X_um);
     float SizeY = fabs(Point1Y_um - Point2Y_um);
     float SizeZ = fabs(Point1Z_um - Point2Z_um);


### PR DESCRIPTION
## Summary
- return zero voxel dimensions for nonpositive scan-region voxel scales
- return a zero total voxel estimate instead of dividing by an invalid scale
- preserve positive-scale and reversed-point region behavior

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- `git diff --check`
- direct `ScanRegion.cpp` C++17 syntax check
- focused C++17 arithmetic probe for positive, zero, negative, and reversed-point scan regions
- clean patch apply against a fresh `origin/master` clone
- `cd Tools && bash Build.sh 6 Release` still prints the known empty/permission-denied Make command failure