### PR TITLE
Validate Simulation GetSave handles

### DIFF
--- a/Source/Core/Simulator/RPC/SimulationRPCInterface.cpp
+++ b/Source/Core/Simulator/RPC/SimulationRPCInterface.cpp
@@ -727,7 +727,13 @@ std::string SimulationRPCInterface::SimulationGetSave(std::string _JSONRequest) 
     //std::cout << Handle.Sim()->StoredRequestsToString() << '\n';
 
     std::string SaveName;
-    Handle.GetParString("SaveHandle", SaveName);
+    if (!Handle.GetParString("SaveHandle", SaveName)) {
+        return Handle.ErrResponse();
+    }
+    if (SaveName.empty() || SaveName.find_first_of("/\\") != std::string::npos) {
+        Logger_->Log("An Invalid SaveHandle Was Provided " + SaveName, 6);
+        return Handle.ErrResponse(API::BGStatusCode::BGStatusInvalidParametersPassed);
+    }
 
     // Minor security feature (probably still exploitable, so be warned!)
     // We just remove .. from the incoming handle for the image, since they're just files right now
@@ -739,6 +745,10 @@ std::string SimulationRPCInterface::SimulationGetSave(std::string _JSONRequest) 
         Logger_->Log("Detected '..' In SaveName, It's Possible That Someone Is Trying To Do Something Nasty", 8);
         SaveName.erase(i, Pattern.length());
         i = SaveName.find(Pattern, i);
+    }
+    if (SaveName.empty()) {
+        Logger_->Log("An Invalid SaveHandle Was Provided", 6);
+        return Handle.ErrResponse(API::BGStatusCode::BGStatusInvalidParametersPassed);
     }
     std::string SafeHandle = "SavedSimulations/" + SaveName + ".NES";
 


### PR DESCRIPTION
Summary
- Return the existing RPC error response when Simulation/GetSave is missing SaveHandle or receives the wrong type.
- Reject empty handles and path-like handles before building a SavedSimulations path.
- Preserve the existing dot-dot stripping behavior and reject handles that become empty after stripping.

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.\n\nVerification\n- git diff --check\n- Focused source probe confirming SimulationGetSave checks GetParString, rejects empty/path-like handles, and no longer ignores SaveHandle parsing failure.\n- Standalone C++17 validation probe covering missing, empty, slash, backslash, dot-dot-only, dot-dot-stripped, and valid generated save handles.\n- Clean patch apply against fresh origin/master.\n\nBlocked local checks\n- clang++ -std=c++17 -fsyntax-only Source/Core/Simulator/RPC/SimulationRPCInterface.cpp -ISource/Core stops on missing local nlohmann/json.hpp.\n- cd Tools && bash Build.sh 6 Release still prints the known local empty/permission-denied Make command failure.